### PR TITLE
Update ADSP-CARRIERS.md

### DIFF
--- a/docs/ADSP-CARRIERS.md
+++ b/docs/ADSP-CARRIERS.md
@@ -26,3 +26,4 @@ Here's an (almost empty) table with results from different providers. Feel free 
 | US | Verizon US ( Postpaid ) | 01.002 | Version 01.003 does take a real long time connecting, sometimes does not detect sim card |
 | US | Mint Mobile | 01.003 | Data doesn't seem to work on 30.004 |
 | US | T-Mobile | 01.003 | |
+| US | Ting (T-Mobile) | 01.003 | Data is IPv6 only on 30.004 |


### PR DESCRIPTION
I use 30.004 for a while before figuring out that I wasn't getting IPv4 with it - resolv.conf only showed IPv6 and ifconfig only showed IPv6. Went back to 01.003 and immediately got IPv4 back. I'm using T-Mobile via Ting (MVNO), so it might apply to both.