### PR TITLE
fwupd: prototype: hardware IDs are OR and not AND

### DIFF
--- a/tools/fwupd/prototype.xml
+++ b/tools/fwupd/prototype.xml
@@ -37,12 +37,10 @@
   </releases>
   <requires>
     <id compare="ge" version="1.7.6">org.freedesktop.fwupd</id>
-    <!-- Pine64 PinePhone: U-Boot script boot -->
-    <hardware>adad873f-33d3-5477-bd5e-0870eca37444</hardware>
-    <!-- Pine64 PinePhone: UEFI Manufacturer + ProductName -->
-    <hardware>cd16a41d-8ea0-52d1-9e97-4a2c5e94c067</hardware>
-    <!-- Pine64 PinePhone Pro: UEFI Manufacturer + ProductName -->
-    <hardware>10f570fd-23d3-5079-ae3f-5f4bda888bad</hardware>
+    <!-- Pine64 PinePhone: U-Boot script boot: adad873f-33d3-5477-bd5e-0870eca37444 -->
+    <!-- Pine64 PinePhone: UEFI Manufacturer + ProductName: cd16a41d-8ea0-52d1-9e97-4a2c5e94c067 -->
+    <!-- Pine64 PinePhone Pro: UEFI Manufacturer + ProductName: 10f570fd-23d3-5079-ae3f-5f4bda888bad -->
+    <hardware>adad873f-33d3-5477-bd5e-0870eca37444|cd16a41d-8ea0-52d1-9e97-4a2c5e94c067|10f570fd-23d3-5079-ae3f-5f4bda888bad</hardware>
   </requires>
   <keywords>
    %%KEYWORDS%%</keywords>


### PR DESCRIPTION
HWIDS must all be present if they are listed as separate IDs under <requires> Use an OR separator since it is either one of them.

See https://lvfs.readthedocs.io/en/latest/metainfo.html#using-chid