### PR TITLE
Add carrier (Spain - simyo)

### DIFF
--- a/docs/ADSP-CARRIERS.md
+++ b/docs/ADSP-CARRIERS.md
@@ -28,6 +28,7 @@ Here's an (almost empty) table with results from different providers. Feel free 
 | Poland | Orange | 01.003, 30.004 | Data reconnect issues / Dual IPv4/6 issues [2](#2) |
 | Spain | Vodafone ES (Postpaid) | 01.003 | Version 01.002 sometimes doesn't reconnect correctly to data |
 | Spain | Pepephone (Roaming on Orange| 01.003 | No issues found with either version |
+| Spain | Simyo | 01.002, 01.003 | |
 | US | Verizon US ( Postpaid ) | 01.002 | Version 01.003 does take a real long time connecting, sometimes does not detect sim card |
 | US | Mint Mobile | 01.003 | Data doesn't seem to work on 30.004 |
 | US | T-Mobile | 01.003 | |


### PR DESCRIPTION
My experience with Simyo carrier (Spain) while daily driving OG Pinephone for more than a year. Tested with both 01.002 & 01.003.