### PR TITLE
Add Swedish carriers

### DIFF
--- a/docs/ADSP-CARRIERS.md
+++ b/docs/ADSP-CARRIERS.md
@@ -26,6 +26,9 @@ Here's an (almost empty) table with results from different providers. Feel free 
 | Austria | Bob | ? | Network doesn't provide any correct date & time [1](#1) |
 | Germany | 1&1 (using Telefonica network) | 01.003, 30.004 | No issues |
 | Poland | Orange | 01.003, 30.004 | Data reconnect issues / Dual IPv4/6 issues [2](#2) |
+| Sweden | Fello (Telia based) | 01.003 (or 01.002) | No new issues. Updating firmware and installing SDK also fixed VoLTE! Details [here](https://github.com/Eliot-Roxbergh/notes_pinephone) |
+| Sweden | Hallon (Tre based) | 01.003 (or 01.002)  | See above |
+| Sweden | Comviq (Tele2 based) | 01.003 (or 01.002)  | See above |
 | Spain | Vodafone ES (Postpaid) | 01.003 | Version 01.002 sometimes doesn't reconnect correctly to data |
 | Spain | Pepephone (Roaming on Orange| 01.003 | No issues found with either version |
 | Spain | Simyo | 01.002, 01.003 | |


### PR DESCRIPTION
Added results from testing three Swedish carriers on Mobian Phosh (2022-10). Phone revisions 1.1 Braveheart and 1.2 3GB. Basically, same result for all three carriers.