### PR TITLE
make get_recordings simpler

### DIFF
--- a/tools/helpers/retrieve_recordings/get_recordings
+++ b/tools/helpers/retrieve_recordings/get_recordings
@@ -1,21 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 TARGETPATH="/path/to/save/the/recordings/"
-FILESTMP=`adb shell ls /tmp/`
-FILESPERSIST=`adb shell ls /persist/`
 mkdir -p $TARGETPATH
 cd $TARGETPATH
-for file in $FILESTMP; do
-        if [[ $file =~ .*\.(wav) ]]; then
-                THISFILE=$(echo $file|tr -d '\n'|tr -d '\r')
-                echo "Pulling "$THISFILE
-                adb  pull /tmp/${THISFILE} && adb shell rm /tmp/${THISFILE}
-        fi
-done;
-for file in $FILESPERSIST; do
-        if [[ $file =~ .*\.(wav) ]]; then
-                THISFILE=$(echo $file|tr -d '\n'|tr -d '\r')
-                echo "Pulling "$THISFILE
-                adb  pull /persist/${THISFILE} && adb shell rm /tmp/${THISFILE}
-        fi
-done;
-
+for file in $(adb shell 'ls -1d /tmp/A*.wav /persist/A*.wav 2>/dev/null'|tr -d '\r');do
+        echo "Pulling $file"
+        adb pull $file && adb shell rm $file || echo "Failed to Pull $file"
+done

--- a/tools/helpers/retrieve_recordings/get_recordings
+++ b/tools/helpers/retrieve_recordings/get_recordings
@@ -2,7 +2,7 @@
 TARGETPATH="/path/to/save/the/recordings/"
 mkdir -p $TARGETPATH
 cd $TARGETPATH
-for file in $(adb shell 'ls -1d /tmp/A*.wav /persist/A*.wav 2>/dev/null'|tr -d '\r');do
+for file in $(adb shell 'ls -1d /tmp/[A-Z]*.wav /persist/[A-Z]*.wav 2>/dev/null'|tr -d '\r');do
         echo "Pulling $file"
         adb pull $file && adb shell rm $file || echo "Failed to Pull $file"
 done


### PR DESCRIPTION
the A*.wav is to get rid of wave.wav which apears in /tmp sometimes i think from call me

also this seems incredibly prone to overwritting files because the file names are not in actual time they are in time since the modems boot at least for me but i wont publish a fix for that rn