### PR TITLE
Remove udev rules now included in default eg25-manager config

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -10,36 +10,19 @@ This document describes recommended settings you can apply to your Pinephone or 
 User @karl implemented a script and a systemd unit that reads the correct date from the Pinephone and sends it via mmcli to the Modem, you can get instructions to set this up [in his blog](https://karl.kashofer.org/pinephone/114)
 
 ## Pinephone
-1. Frequent disconnects and reconnects (Modem vanishes and reappears a few seconds later during operation or after waking up from suspend)
 
-Sometimes the kernel is too aggressive trying to suspend the USB port when it's actually in use. Disabling runtime suspend for the port usually helps a lot. 
-- Edit `/usr/lib/udev/rules.d/80-modem-eg25.rules`
-- Look at the first line where it says `ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{power/control}="auto"`
-- And change it to ON `ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{power/control}="on"`
-
-2. Audio volume is too low
+1. Audio volume is too low
 - Edit the ALSA UCM config file `/usr/share/alsa/ucm2/PinePhone/VoiceCall.conf` and look for the following parameters:
   - `AIF2 DAC Playback Volume`
   - `AIF2 ADC Capture Volume`
 - Replace their values with `80%` or `90%` (some people noticed that 90% gets echo at the other side of the call, but doesn't happen to everyone, so feel free to experiment with the most suitable values for you) 
 
 ## PinePhone Pro
-1. Stop the modem from disappearing on suspend
- - Edit `/usr/lib/udev/rules.d/80-modem-eg25.rules`
- - Look at the last line: `ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{power/persist}="0"`
- - And change persist to 1: `ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{power/persist}="1"`
- - Edit `/usr/share/eg25-manager/pine64,pinephone-pro.toml` and make sure `monitor_udev` is set to `false`
-
-2. Messages appear twice. The same problem as with the original Pinephone, but different behaviour. Some times the modem's USB port is suspended during a transaction, ending up in ModemManager losing a QMI message during a transaction. This manifests on SMS not being deleted from the modem because that part of the transaction was lost, or a message bein received twice. If this happens to you, here is an easy fix:
-- Edit `/usr/lib/udev/rules.d/80-modem-eg25.rules`
-- Look at the first line where it says `ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{power/control}="auto"`
-- And change it to ON `ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{power/control}="on"`
-
-3. Microphone audio is too loud during phone calls ( distorted audio and lots of background noise from your side )
+1. Microphone audio is too loud during phone calls ( distorted audio and lots of background noise from your side )
 - Edit the ALSA UCM config file `/usr/share/alsa/ucm2/PinePhonePro/VoiceCall.conf` and look for the following parameters:
   - `IN1 Boost`
 - Change the default value from 8 to 3 ( YMMV you may need to go a bit higher or lower, but 8 is way too much in my testing ).
 
-4. If 1 and 2 are not enough, and you are using a megi kernel ( archlinux for example ) or a kernel that adds the reset quirk to the modem:
+2. If you are using a megi kernel ( archlinux for example ) or a kernel that adds the reset quirk to the modem:
  - Edit `/usr/lib/udev/rules.d/80-modem-eg25.rules`
  - Add a new line after `ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{power/persist}="1"` that reads `ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ATTR{avoid_reset_quirk}="0"`


### PR DESCRIPTION
eg25-manager added logic to it's udev rules a while ago to check for the community firmware and change the applied values accordingly. The values recommended here are now the default, so changing them manually is no longer necessary.

see also: https://gitlab.com/mobian1/eg25-manager/-/blob/e7790f941c053837e596dccd92ba97051a2d4cc1/udev/80-modem-eg25.rules