### PR TITLE
Fix boot-mdm9607.img name; add AT+ADBON info; mmcli update

### DIFF
--- a/docs/AT_INTERFACE.md
+++ b/docs/AT_INTERFACE.md
@@ -10,7 +10,8 @@ These are all the base commands that appear in Quectel's AT Command Manual (Vers
 
 To connect to the serial terminal with local echo and automatic LF trimming, you can use `sudo picocom --echo --omap ignlf /dev/ttyUSB2`.
 
-Alternatively, you can use mmcli to run a command non-interactively: `sudo mmcli -m any --command='AT+QMBNCFG="list"'`
+Alternatively, you can use mmcli to run a command non-interactively: `sudo mmcli -m any --command='AT+QMBNCFG="list"'`.
+In systemd OSes such as Mobian as of 2023, you will likely need to stop ModemManager and run it in debug mode in a separate terminal: `systemctl stop ModemManager; ModemManager --debug`, and then run `mmcli` commands as ordinary user.
 
 ### Notes:
 Handled by can be

--- a/docs/FLASHING.md
+++ b/docs/FLASHING.md
@@ -51,8 +51,8 @@ If your Pinephone / Pro came with a really old stock firmware, you might need to
 7. Now you can flash everything:
   * `fastboot flash boot boot-mdm9607.img`
     * If you get an error flashing the kernel, run fastboot flash:raw : `fastboot flash:raw boot boot-mdm9607.img`
-  * `fastboot flash recovery mdm9607-boot.img`
+  * `fastboot flash recovery boot-mdm9607.img`
   * `fastboot flash system rootfs-mdm9607.ubi`
   * `fastboot flash recoveryfs recoveryfs.ubi`
 8. After you flashed everything, you can run 'fastboot reboot' and wait for it to come back (you might have to run `fastboot reboot` twice to clear Quectel's bootloader flags).
-
+9. If all has gone well, to enable `adb` you will likely need to send the "AT+ADBON" command to the modem.


### PR DESCRIPTION
This commit proposes several documentation fixes:

- the file boot-mdm9607.img is wrongly given as mdm9607.img in FLASHING.md;

- telling the user about AT+ADBON in FLASHING.md may save some time searching;

- 'mmcli' is in userspace in current Mobian, and more importantly, debug mode for ModemManager needs to be used - a brief comment on this is added to AT_INTERFACE.md .